### PR TITLE
Fix out of bound warning from MobX

### DIFF
--- a/src/ChatFeed/index.tsx
+++ b/src/ChatFeed/index.tsx
@@ -64,7 +64,7 @@ export default class ChatFeed extends React.Component {
     const messageNodes = messages.map((message, index) => {
       group.push(message);
       // Find diff in message type or no more messages
-      if (!messages[index + 1] || messages[index + 1].id !== message.id) {
+      if (index === messages.length - 1 || messages[index + 1].id !== message.id) {
         const messageGroup = group;
         group = [];
         return (


### PR DESCRIPTION
When using react-chat-ui with MobX, it shows warning messages about out of bound.

Warning Messages:

```
...
[mobx.array] Attempt to read an array index (34) that is out of bounds (34). Please check length first. Out of bound indices will not be tracked by MobX
[mobx.array] Attempt to read an array index (35) that is out of bounds (35). Please check length first. Out of bound indices will not be tracked by MobX
```

This warning occurred because of checking the array index is exist or not.

```
if (!messages[index + 1] || messages[index + 1].id !== message.id) {
    ...
```

I think check the length of messages array is good rather than check out of bound.

close #30 

